### PR TITLE
Use root path env

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Chemical should have the following structure:
 
   * `c.source` having value typeof
     * Function - used as Class constructor
-    * String - used as path relative to `process.env.NODE_PATH` || `process.cwd()`  to require Class implementation
+    * String - used as path relative to `process.env.ROOT_PATH` || `process.cwd()`  to require Class implementation
 
 All Modules representing Organelles instantiated by Nucleus are expected to have the following signature
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports.prototype.buildOne = function(c, callback){
     return callback && callback(new Error("can not create object without source but with "+util.inspect(c)));
   var source = objectConfig.source;
   if(source.indexOf("/") !== 0 && source.indexOf(":\\") !== 1)
-    source = (process.env.NODE_PATH || process.cwd())+"/"+source;
+    source = (process.env.ROOT_PATH || process.cwd())+"/"+source;
   var OrganelClass = require(source);
   var instance = new OrganelClass(this.plasma, objectConfig);
   return callback && callback(null, instance);

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports.prototype.buildOne = function(c, callback){
   if(!objectConfig.source)
     return callback && callback(new Error("can not create object without source but with "+util.inspect(c)));
   var source = objectConfig.source;
-  if(source.indexOf("/") !== 0 && source.indexOf(":\\") !== 1)
+  if(source.indexOf("/") !== -1 || source.indexOf("\\") !== -1)
     source = (process.env.ROOT_PATH || process.cwd())+"/"+source;
   var OrganelClass = require(source);
   var instance = new OrganelClass(this.plasma, objectConfig);


### PR DESCRIPTION
since `process.env.NODE_PATH` is location to `node_modules` folder it's better to use other env variable like `ROOT_PATH` (or `ORGANELLES_ROOT` ? :smile:) to resolve organelles with relative source