### PR TITLE
require organelle by module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ Chemical should have the following structure:
 
     {
       "source": "relative/path/to/organelle",
+      "source": "organic-organelle-name-also-works",
       // ... organelle's own dna data
     }
 
 
   * `c.source` having value typeof
     * Function - used as Class constructor
-    * String - used as path relative to `process.env.NODE_PATH` || `process.cwd()`  to require Class implementation
+    * String - used as path relative to `process.cwd()` or package name (as installed module) to require Class implementation
 
 All Modules representing Organelles instantiated by Nucleus are expected to have the following signature
 

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ module.exports.prototype.buildOne = function(c, callback){
   if(!objectConfig.source)
     return callback && callback(new Error("can not create object without source but with "+util.inspect(c)));
   var source = objectConfig.source;
-  if(source.indexOf("/") !== 0 && source.indexOf(":\\") !== 1)
-    source = (process.env.NODE_PATH || process.cwd())+"/"+source;
+  if(source.indexOf("/") !== -1 || source.indexOf("\\") !== -1)
+    source = process.cwd()+"/"+source;
   var OrganelClass = require(source);
   var instance = new OrganelClass(this.plasma, objectConfig);
   return callback && callback(null, instance);


### PR DESCRIPTION
if organelle.source doesn't contain `/` or `\` then process.cwd() isn't prefixed to source, this way we can require npm installed organelles and still load custom ones :)